### PR TITLE
[WIP] Override workflow for payments-cod.

### DIFF
--- a/client/components/codPaymentForm.js
+++ b/client/components/codPaymentForm.js
@@ -17,7 +17,7 @@ class CodPaymentForm extends React.Component {
     const paymentMethod = {
       processor: "payments-cod",
       paymentPackageId: this.props.paymentPackageId,
-      method: "debit",
+      method: "credit",
       amount: Number(this.props.cartTotal),
       paymentSettingsKey: "payments-cod",
       transactionId: Random.id(),

--- a/client/components/codPaymentMethodApproved.js
+++ b/client/components/codPaymentMethodApproved.js
@@ -1,0 +1,36 @@
+import React from "react";
+import { registerComponent } from "@reactioncommerce/reaction-components";
+
+
+class CodPaymentMethodApproved extends React.Component {
+  onPaymentReceived = () => {
+    // Finish up workflow
+    this.props.paymentMethodWorkflow.pushNextState("paymentReceived");
+  }
+
+  render() {
+    return (
+      <div className="flex">
+        <a
+          className="btn btn-link"
+          href={this.props.printOrder}
+          target="_blank"
+          data-i18n="app.print"
+        >
+          Print
+        </a>
+
+        <button
+          className="btn btn-success flex-item-fill"
+          type="button"
+          data-event-action="capturePayment"
+          onClick={this.onPaymentReceived}
+        >
+          <span id="btn-capture-payment" data-i18n="">Payment received</span>
+        </button>
+      </div>
+    );
+  }
+}
+
+registerComponent("CodPaymentMethodApproved", CodPaymentMethodApproved);

--- a/client/components/index.js
+++ b/client/components/index.js
@@ -1,2 +1,3 @@
 import "./codPaymentSettings";
 import "./codPaymentForm";
+import "./codPaymentMethodApproved";

--- a/register.js
+++ b/register.js
@@ -31,7 +31,31 @@ Reaction.registerPackage({
       provides: ["paymentMethod"],
       icon: "fa fa-money"
     }
-  ]
+  ],
+  layout: [{
+    state: "approved",
+    template: "CodPaymentMethodApproved",
+    workflow: "paymentMethod"
+  }, {
+    state: "completed",
+    // template: "", // no template to render for now
+    workflow: "paymentMethod"
+  }],
+  stateflows: [{
+    name: "payments-cod", // same as in paymentSettingsKey
+    workflow: "paymentMethod",
+    collection: "Orders",
+    querySelector: "{ \"_id\": \"${this.docId}\", \"billing.shopId\": \"${this.shopId}\"}",
+    locationPath: "billing.$.paymentMethod.workflow",
+    strategy: "StateflowSimpleStrategy",
+    fsm: {
+      init: "created",
+      transitions: [
+        { name: "approvePayment", from: "created", to: "approved" },
+        { name: "paymentReceived", from: "approved", to: "completed" }
+      ]
+    }
+  }]
 });
 
 


### PR DESCRIPTION
Warning: This involves significant changes to processing of
paymentmethods. It's not completed, but it should work for these
two paymentmethods: payments-cod & example-payment

For testing, branch michael-workflow-for-payments is needed.

Changes:
  - Generic mechanism for defining workflows through
  javascript-state-machine
  - Allows to customize transisitions between states via Strategy API
  - Connect workflow states to workflow-steps in registry.
  - Helper to render visual representation of current state
  - Stateflows can be used client and server side (haven't tested server
  side yet)
  - Generic save method for all Stateflows (workflow/setState)
  - probably a couple of other things..